### PR TITLE
Fix issues with navigation and scroll positions

### DIFF
--- a/src/components/navigation/NavBar.vue
+++ b/src/components/navigation/NavBar.vue
@@ -73,6 +73,7 @@ export default {
       showNav: true,
       lastScrollPos: 0,
       currentScrollPos: 0,
+      thresholdBeforeNavHide: 300,
       headshot: require("@/assets/img/headshot.jpeg"),
       internalLinks: [
         {
@@ -106,7 +107,10 @@ export default {
         return;
       }
 
-      if (this.lastScrollPos < window.scrollY) {
+      if (
+        this.lastScrollPos < window.scrollY &&
+        window.scrollY > this.thresholdBeforeNavHide
+      ) {
         this.showNav = false;
       }
 

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,9 @@ Vue.use(Router);
 
 export default new Router({
   mode: 'history',
+  scrollBehavior (to, from, savedPosition) {
+    return { x: 0, y: 0 }
+  },
   routes: [
     {
       path: '/',


### PR DESCRIPTION
- Change scrollBehavior on router to reset x,y scroll positions when changing routes so users do not need to scroll back to the top when clicking on a router-link at the bottom of a page.
- Navbar will no longer hide immediately on scroll down and will instead need to breach a threshold of 300px. Scrolling up will still reveal the navbar immediately.