### PR TITLE
improvement(frameworkcircle): add stack item name on hover/click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,6 +2659,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "balloon-css": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/balloon-css/-/balloon-css-1.0.4.tgz",
+      "integrity": "sha512-sq9vMyTN8dVYPvoS0rTSxlfYq2tPNM9E2t30CHJlRDUQibD6PtMVHjTbbpj3yRZvMPFev31lggAOLG2cxmwJ7w=="
+    },
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vanillawc/wc-markdown": "^1.3.4",
     "axios": "^0.19.0",
     "babel-runtime": "^6.26.0",
+    "balloon-css": "^1.0.4",
     "chart.js": "^2.9.3",
     "core-js": "^2.6.10",
     "gsap": "^2.1.3",

--- a/public/index.html
+++ b/public/index.html
@@ -27,12 +27,10 @@
     <!-- PrismJS -->
     <link
       rel="stylesheet"
+      type="text/css"
       href="https://cdn.jsdelivr.net/npm/prism-themes@1.3.0/themes/prism-atom-dark.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/components/prism-json.min.js"
-    />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/components/prism-json.min.js"></script>
     <script src="https://unpkg.com/prismjs"></script>
 
     <title>CodeSpent | Fullstack Engineer</title>

--- a/src/components/home/FrameworkCircle.vue
+++ b/src/components/home/FrameworkCircle.vue
@@ -1,14 +1,34 @@
 <template>
   <ul class="circle-container m-5 mt-10 mb-10">
     <li
-      v-for="brand in brands"
+      v-for="(brand, index) in brands"
       :key="brand.name"
+      @mouseover="showBrandDetails(index)"
+      @mouseleave="activeBrand = false"
     >
       <img
         :src="brand.src"
-        alt="..."
+        :alt="brand.name"
         width="80px"
       >
+    </li>
+
+    <li v-if="activeBrand">
+      <div class="brand-details flex flex-col items-center">
+        <div class="flex flex-row items-center">
+          <img
+            :src="activeBrand.src"
+            :alt="activeBrand.name"
+            class="mr-2"
+            style="height: 50px;"
+          >
+          <div class="flex flex-col justify-center text-center">
+            <h1 class="text-white font-black text-2xl mt-2">
+              {{ activeBrand.name }}
+            </h1>
+          </div>
+        </div>
+      </div>
     </li>
   </ul>
 </template>
@@ -17,9 +37,10 @@
 export default {
   data() {
     return {
+      activeBrand: false,
       brands: [
         {
-          name: "Vue",
+          name: "VueJS",
           src: require("@/assets/img/brands/logo.png")
         },
         {
@@ -27,7 +48,7 @@ export default {
           src: require("@/assets/img/brands/django.svg")
         },
         {
-          name: "React",
+          name: "ReactJS",
           src: require("@/assets/img/brands/react.png")
         },
         {
@@ -39,7 +60,7 @@ export default {
           src: require("@/assets/img/brands/gridsome.svg")
         },
         {
-          name: "Angular",
+          name: "AngularJS",
           src: require("@/assets/img/brands/angular.svg")
         },
         {
@@ -60,6 +81,11 @@ export default {
         }
       ]
     };
+  },
+  methods: {
+    showBrandDetails(index) {
+      this.activeBrand = this.brands[index];
+    }
   }
 };
 </script>
@@ -111,5 +137,9 @@ export default {
     max-width: 100%;
     transition: 0.15s;
   }
+}
+
+.brand-details {
+  margin-left: -40px;
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,9 @@ import VueResource from 'vue-resource';
 // import tailwind css
 import '@/assets/css/tailwind.css';
 
+// import baloon css
+import 'balloon-css';
+
 // import prism editor
 import 'prismjs/components/prism-json.js';
 import VuePrismEditor from 'vue-prism-editor';


### PR DESCRIPTION
This commit adds a list-item to the center of the framework circle that displays the currently
active items by mouseover/mouseleave. On desktop this will be invoked with a hover, on mobile this
will be invoked by a tap.

re #3