### PR TITLE
ci(netlify): add `source` redirect to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[redirects]]
+  from = "/source"
+  to = "https://github.com/CodeSpent/codespent-website"
+  status = 302


### PR DESCRIPTION
Add a redirect at /source that redirects to the Github repo for codespent-website.