### PR TITLE
Fix/highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,9 +1264,9 @@
       "dev": true
     },
     "@vanillawc/wc-markdown": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@vanillawc/wc-markdown/-/wc-markdown-1.3.4.tgz",
-      "integrity": "sha512-SvrLPaddomGyNb/+lJA1GUK+EoAGFpc71MMXrCZ16wAWkecFR3QikmhA/G3aTbM3UYhiyaC3ycyY/eQYRvQLdw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vanillawc/wc-markdown/-/wc-markdown-1.5.0.tgz",
+      "integrity": "sha512-vymwmRaC2qLPmchquBWjszWZO5QfxDO8OcRv1y32857vqqbxeR4bYr+hMkCydZAzdO9XnWYrR7v7Japl5jRIEQ=="
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/vue-fontawesome": "^0.1.8",
-    "@vanillawc/wc-markdown": "^1.3.4",
+    "@vanillawc/wc-markdown": "^1.5.0",
     "axios": "^0.19.0",
     "babel-runtime": "^6.26.0",
     "balloon-css": "^1.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -30,9 +30,6 @@
       type="text/css"
       href="https://cdn.jsdelivr.net/npm/prism-themes@1.3.0/themes/prism-atom-dark.css"
     />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/components/prism-json.min.js"></script>
-    <script src="https://unpkg.com/prismjs"></script>
-
     <title>CodeSpent | Fullstack Engineer</title>
   </head>
   <body>

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import 'balloon-css';
 import VuePrismEditor from 'vue-prism-editor';
 import 'vue-prism-editor/dist/VuePrismEditor.css';
 import 'prismjs/components/prism-json.js';
+import 'prismjs/components/prism-python.js';
 
 // import font-awesome icons
 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/src/main.js
+++ b/src/main.js
@@ -10,9 +10,9 @@ import '@/assets/css/tailwind.css';
 import 'balloon-css';
 
 // import prism editor
-import 'prismjs/components/prism-json.js';
 import VuePrismEditor from 'vue-prism-editor';
 import 'vue-prism-editor/dist/VuePrismEditor.css';
+import 'prismjs/components/prism-json.js';
 
 // import font-awesome icons
 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,9 @@ import '@/assets/css/tailwind.css';
 // import baloon css
 import 'balloon-css';
 
+// import wc-markdown
+import '@vanillawc/wc-markdown';
+
 // import prism editor
 import VuePrismEditor from 'vue-prism-editor';
 import 'vue-prism-editor/dist/VuePrismEditor.css';

--- a/src/views/blog/BlogPostView.vue
+++ b/src/views/blog/BlogPostView.vue
@@ -51,10 +51,10 @@
       <font-awesome-icon icon="book-open" />&nbsp;Read on
       Dev.to
     </a>
-    <div
+    <wc-markdown
       id="article-content"
       class="container article text-left"
-      v-html="article.body_html"
+      highlight
     />
   </div>
 </template>
@@ -78,6 +78,8 @@ export default {
         switch (response.status) {
           case 200: {
             this.article = response.data;
+            const mdElement = document.getElementById('article-content');
+            mdElement.value = this.article.body_markdown;
             break;
           }
           default: {


### PR DESCRIPTION
Ref: #1

This fixes syntax-highlighting for blog posts by using wc-markdown to parse the document body.

The only downside being, you're now loading 2 different markdown web components that depend on PrismJS.